### PR TITLE
Pull more recent version of epmdless on epmdless_example

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-    {epmdless, ".*", {git, "https://github.com/oltarasenko/epmdless", {tag, "0.1.0"}}}
+    {epmdless, ".*", {git, "https://github.com/oltarasenko/epmdless", {tag, "0.1.4"}}}
 ]}.
 {relx, [{release, { sample_app, "0.1.0" },
          [sample_app,


### PR DESCRIPTION
Whilst this doesn't fix the issues I was having it seems better to be using the most recent version.