### PR TITLE
Use newer epmdless

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-    {epmdless, ".*", {git, "https://github.com/oltarasenko/epmdless", {tag, "0.1.0"}}},
+    {epmdless, ".*", {git, "https://github.com/oltarasenko/epmdless", {tag, "0.1.4"}}},
     {erlang_node_discovery, ".*", {git, "https://github.com/oltarasenko/erlang-node-discovery", {tag, "0.1.2"}}}
 ]}.
 {relx, [{release, { sample_app, "0.1.0" },


### PR DESCRIPTION
Previously versions had logging that was confusing as it didn't match
the output suggested in the readme. This helps (along with having
useful fixes)